### PR TITLE
test: use local action in testing workflows

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -8,9 +8,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-18.04, ubuntu-20.04]
     steps:
     - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@main
-      with:
-        run_local_checkout: 'true'
+    - uses: ./github-action-cvmfs
     - name: Test CernVM-FS
       run: |
         echo "### Dump default.local ###"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -8,7 +8,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-18.04, ubuntu-20.04]
     steps:
     - uses: actions/checkout@v2
-    - uses: ./github-action-cvmfs
+    - uses: ./
     - name: Test CernVM-FS
       run: |
         echo "### Dump default.local ###"


### PR DESCRIPTION
Instead of using `run_local_checkout` it is less confusing to use a local path to the checkout directory.